### PR TITLE
Backend - Country validators

### DIFF
--- a/server/helpers.js
+++ b/server/helpers.js
@@ -1,3 +1,5 @@
+const companyData = require("./data/companies.json");
+
 const MAX_DELAY = 2000;
 const FAILURE_ODDS = 0;
 
@@ -24,4 +26,4 @@ const getCountryList = () => {
   return uniqueCountries;
 };
 
-module.exports = { simulateProblems };
+module.exports = { simulateProblems, getCountryList };

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -16,4 +16,12 @@ const simulateProblems = (res, data) => {
   }, delay);
 };
 
+const getCountryList = () => {
+  const countryList = companyData.map((country) => {
+    return country.country;
+  });
+  const uniqueCountries = Array.from(new Set(countryList));
+  return uniqueCountries;
+};
+
 module.exports = { simulateProblems };

--- a/server/index.js
+++ b/server/index.js
@@ -48,25 +48,34 @@ express()
   })
 
   //----Gets the Products by each country----//
-
   .get("/products/:country", (req, res) => {
     const { country } = req.params;
-    const companiesIdByCountry = companyData
-      .map((company) => {
-        if (
-          company.country.replace(" ", "").toLowerCase() ===
-          country.toLowerCase()
-        ) {
-          return company.id;
-        }
-      })
-      .filter((id) => id !== undefined);
-    const productsByCountry = companiesIdByCountry.map((id) => {
-      return productData.filter((product) => {
-        return product.companyId === id;
-      });
+    const countryList = getCountryList().map((country) => {
+      return country.toLowerCase();
     });
-    return simulateProblems(res, { products: _.flatten(productsByCountry) });
+
+    if (countryList.includes(country.toLowerCase())) {
+      const companiesIdByCountry = companyData
+        .map((company) => {
+          if (
+            company.country.replace(" ", "").toLowerCase() ===
+            country.replace(" ", "").toLowerCase()
+          ) {
+            return company.id;
+          }
+        })
+        .filter((id) => id !== undefined);
+      const productsByCountry = companiesIdByCountry.map((id) => {
+        return productData.filter((product) => {
+          return product.companyId === id;
+        });
+      });
+      return simulateProblems(res, { products: _.flatten(productsByCountry) });
+    } else {
+      res.status(404).send({
+        error: `We either don't sell in that country or we couldn't find what you're looking for.`,
+      });
+    }
   })
 
   .get("/products/detail/:productId", (req, res) => {

--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,7 @@ const morgan = require("morgan");
 const companyData = require("./data/companies.json");
 const productData = require("./data/items.json");
 const _ = require("lodash");
-const { simulateProblems } = require("./helpers.js");
+const { simulateProblems, getCountryList } = require("./helpers.js");
 const PORT = 4000;
 express()
   .use(function (req, res, next) {
@@ -31,11 +31,7 @@ express()
   //---Gets Country List in an Array---//
 
   .get("/countries", (req, res) => {
-    const countryList = companyData.map((country) => {
-      return country.country;
-    });
-    const uniqueCountries = Array.from(new Set(countryList));
-
+    const uniqueCountries = getCountryList();
     res.status(200).send({ countries: uniqueCountries });
   })
 


### PR DESCRIPTION
This PR does the following:

- adds an extra helper function in `helper.js`  to avoid code duplication

- allows Front  End to get better data from the Backend, without having to manipulate endpoints with `replace(" ", "")`, for example:

<img width="648" alt="Screenshot 2020-04-16 at 11 51 49" src="https://user-images.githubusercontent.com/22174780/79477869-bab04880-7fd8-11ea-878e-0f77877ac3ee.png">
<img width="653" alt="Screenshot 2020-04-16 at 11 51 37" src="https://user-images.githubusercontent.com/22174780/79477870-bab04880-7fd8-11ea-948d-022f58addefc.png">
<img width="658" alt="Screenshot 2020-04-16 at 11 52 00" src="https://user-images.githubusercontent.com/22174780/79477883-bc7a0c00-7fd8-11ea-8d3e-ee49aff0e2c6.png">

- adds validation to country name. It will error in case someone wants to access an endpoint with a country or any info that is not present in our country list.

Example:

`GET localhost:4000/products/india`
Should return a 404 with an error object: {
  "error": "We either don't sell in that country or we couldn't find what you're looking for."
}

<img width="654" alt="Screenshot 2020-04-16 at 11 51 03" src="https://user-images.githubusercontent.com/22174780/79477753-95bbd580-7fd8-11ea-83c1-ed89326b3f3a.png">



